### PR TITLE
Update: Yew 0.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -227,6 +227,25 @@ dependencies = [
  "gloo-timers 0.2.6",
  "gloo-utils 0.1.7",
  "gloo-worker 0.2.1",
+]
+
+[[package]]
+name = "gloo"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd35526c28cc55c1db77aed6296de58677dbab863b118483a27845631d870249"
+dependencies = [
+ "gloo-console 0.3.0",
+ "gloo-dialogs 0.2.0",
+ "gloo-events 0.2.0",
+ "gloo-file 0.3.0",
+ "gloo-history 0.2.2",
+ "gloo-net 0.4.0",
+ "gloo-render 0.2.0",
+ "gloo-storage 0.3.0",
+ "gloo-timers 0.3.0",
+ "gloo-utils 0.2.0",
+ "gloo-worker 0.4.0",
 ]
 
 [[package]]
@@ -394,6 +413,27 @@ dependencies = [
 
 [[package]]
 name = "gloo-net"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ac9e8288ae2c632fa9f8657ac70bfe38a1530f345282d7ba66a1f70b72b7dc4"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-sink",
+ "gloo-utils 0.2.0",
+ "http",
+ "js-sys",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-net"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43aaa242d1239a8822c15c645f02166398da4f8b5c4bae795c1f5b44e9eee173"
@@ -528,6 +568,25 @@ dependencies = [
 
 [[package]]
 name = "gloo-worker"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76495d3dd87de51da268fa3a593da118ab43eb7f8809e17eb38d3319b424e400"
+dependencies = [
+ "bincode",
+ "futures",
+ "gloo-utils 0.2.0",
+ "gloo-worker-macros",
+ "js-sys",
+ "pinned",
+ "serde",
+ "thiserror",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-worker"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "085f262d7604911c8150162529cefab3782e91adb20202e8658f7275d2aefe5d"
@@ -554,14 +613,8 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.87",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -588,21 +641,22 @@ dependencies = [
 
 [[package]]
 name = "implicit-clone"
-version = "0.3.9"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd6201e7c30ccb24773cac7efa6fec1e06189d414b7439ce756a481c8bfbf53"
+checksum = "f8a9aa791c7b5a71b636b7a68207fdebf171ddfc593d9c8506ec4cbc527b6a84"
 dependencies = [
- "indexmap 1.9.3",
+ "implicit-clone-derive",
+ "indexmap",
 ]
 
 [[package]]
-name = "indexmap"
-version = "1.9.3"
+name = "implicit-clone-derive"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+checksum = "9311685eb9a34808bbb0608ad2fcab9ae216266beca5848613e95553ac914e3b"
 dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -612,7 +666,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown",
 ]
 
 [[package]]
@@ -705,7 +759,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -739,12 +793,12 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prettyplease"
-version = "0.1.25"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
+checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
- "syn 1.0.109",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -909,7 +963,7 @@ checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -951,15 +1005,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
- "quote",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.67"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff8655ed1d86f3af4ee3fd3263786bc14245ad17c4c7e85ba7187fb3ae028c90"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -983,7 +1036,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1019,7 +1072,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap",
  "toml_datetime",
  "winnow",
 ]
@@ -1043,7 +1096,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1105,7 +1158,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.87",
  "wasm-bindgen-shared",
 ]
 
@@ -1139,7 +1192,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.87",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1172,7 +1225,7 @@ checksum = "b7f89739351a2e03cb94beb799d47fb2cac01759b40ec441f7de39b00cbf7ef0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1196,15 +1249,15 @@ dependencies = [
 
 [[package]]
 name = "yew"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dbecfe44343b70cc2932c3eb445425969ae21754a8ab3a0966981c1cf7af1cc"
+checksum = "5f1a03f255c70c7aa3e9c62e15292f142ede0564123543c1cc0c7a4f31660cac"
 dependencies = [
  "console_error_panic_hook",
  "futures",
- "gloo 0.8.1",
+ "gloo 0.10.0",
  "implicit-clone",
- "indexmap 1.9.3",
+ "indexmap",
  "js-sys",
  "prokio",
  "rustversion",
@@ -1221,9 +1274,9 @@ dependencies = [
 
 [[package]]
 name = "yew-macro"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b64c253c1d401f1ea868ca9988db63958cfa15a69f739101f338d6f05eea8301"
+checksum = "02fd8ca5166d69e59f796500a2ce432ff751edecbbb308ca59fd3fe4d0343de2"
 dependencies = [
  "boolinator",
  "once_cell",
@@ -1231,5 +1284,5 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.87",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ DoughnutChart = []
 
 
 [dependencies]
-yew = { version="0.20", features=["csr"] }
+yew = { version="0.21", features=["csr"] }
 web-sys = { version = "0.3.69", features = ["HtmlSelectElement", "HtmlDocument", "HtmlCanvasElement", "CanvasRenderingContext2d"]}
 gloo = "0.11.0"
 rand = "0.8.5"

--- a/src/charts/bar_chart/bar_chart.rs
+++ b/src/charts/bar_chart/bar_chart.rs
@@ -33,7 +33,7 @@ pub fn BarChart(props: &BarChartProps) -> Html {
     {
         let canvas_ref = canvas_ref.clone();
         let props_clone = props.clone();
-        use_effect_with_deps(move |_| {
+        use_effect_with((), move |_| {
             let canvas = canvas_ref.cast::<HtmlCanvasElement>().expect("Failed to get canvas element");
 
             let context = canvas
@@ -73,7 +73,7 @@ pub fn BarChart(props: &BarChartProps) -> Html {
             });
 
             move || drop(listener) // Clean up the event listener on component unmount
-        }, ());
+        });
     }
 
     html! {

--- a/src/charts/doughnut_chart/doughnut_chart.rs
+++ b/src/charts/doughnut_chart/doughnut_chart.rs
@@ -22,7 +22,7 @@ pub fn DoughnutChart(props: &DoughnutChartProps) -> Html {
     {
         let canvas_ref = canvas_ref.clone();
         let props_clone = props.clone();
-        use_effect_with_deps(move |_| {
+        use_effect_with((), move |_| {
             let canvas = canvas_ref.cast::<HtmlCanvasElement>().expect("Failed to get canvas element");
 
             let context = canvas
@@ -62,7 +62,7 @@ pub fn DoughnutChart(props: &DoughnutChartProps) -> Html {
             });
 
             move || drop(listener) // Clean up the event listener on component unmount
-        }, ());
+        });
     }
 
     let legend_html = if props.config.show_legend {

--- a/src/charts/line_chart/line_chart.rs
+++ b/src/charts/line_chart/line_chart.rs
@@ -63,7 +63,7 @@ pub fn LineCurveChart(props: &LineCurveChartProps) -> Html {
     {
         let canvas_ref = canvas_ref.clone();
         let props_clone = props.clone();
-        use_effect_with_deps(
+        use_effect_with((), 
             move |_| {
                 let canvas = canvas_ref
                     .cast::<HtmlCanvasElement>()
@@ -111,8 +111,7 @@ pub fn LineCurveChart(props: &LineCurveChartProps) -> Html {
                 });
 
                 move || drop(listener) // Clean up the event listener on component unmount
-            },
-            (),
+            }
         );
     }
 

--- a/src/charts/pie_chart/pie_chart.rs
+++ b/src/charts/pie_chart/pie_chart.rs
@@ -32,7 +32,7 @@ pub fn PieChart(props: &PieChartProps) -> Html {
     {
         let canvas_ref = canvas_ref.clone();
         let props_clone = props.clone();
-        use_effect_with_deps(move |_| {
+        use_effect_with((), move |_| {
             let canvas = canvas_ref.cast::<HtmlCanvasElement>().expect("Failed to get canvas element");
 
             let context = canvas
@@ -72,7 +72,7 @@ pub fn PieChart(props: &PieChartProps) -> Html {
             });
 
             move || drop(listener) // Clean up the event listener on component unmount
-        }, ());
+        });
     }
 
     let legend_html = if props.config.show_legend {


### PR DESCRIPTION
This pull request includes updates to dependencies and refactoring of the `use_effect_with_deps` hook to `use_effect_with` in various chart components. The most important changes include updating the `yew` dependency version and refactoring the `use_effect_with_deps` hook in the `BarChart`, `DoughnutChart`, `LineCurveChart`, and `PieChart` components.

Dependency update:

* Updated `yew` dependency version from `0.20` to `0.21` in `Cargo.toml`.

Refactoring `use_effect_with_deps` to `use_effect_with`:

* Refactored the `use_effect_with_deps` hook to `use_effect_with` in the `BarChart` component in `src/charts/bar_chart/bar_chart.rs`. [[1]](diffhunk://#diff-3dd04b54402931300dac8f907006dce555aa3493e0832ecc4a2ca870d6bc7032L36-R36) [[2]](diffhunk://#diff-3dd04b54402931300dac8f907006dce555aa3493e0832ecc4a2ca870d6bc7032L76-R76)
* Refactored the `use_effect_with_deps` hook to `use_effect_with` in the `DoughnutChart` component in `src/charts/doughnut_chart/doughnut_chart.rs`. [[1]](diffhunk://#diff-7272aa156857981d5878ef0611d013dfa0b6a0b6f7f32db9bd83e2cdd3cc5c11L25-R25) [[2]](diffhunk://#diff-7272aa156857981d5878ef0611d013dfa0b6a0b6f7f32db9bd83e2cdd3cc5c11L65-R65)
* Refactored the `use_effect_with_deps` hook to `use_effect_with` in the `LineCurveChart` component in `src/charts/line_chart/line_chart.rs`. [[1]](diffhunk://#diff-1e22136fba226903d30252c41f387a02f997e56ec18dac55c0e4dc53b5de27deL66-R66) [[2]](diffhunk://#diff-1e22136fba226903d30252c41f387a02f997e56ec18dac55c0e4dc53b5de27deL114-R114)
* Refactored the `use_effect_with_deps` hook to `use_effect_with` in the `PieChart` component in `src/charts/pie_chart/pie_chart.rs`. [[1]](diffhunk://#diff-f368266b277140cdb2900cd37bbb4546863769b1418381514adc51d65046469cL35-R35) [[2]](diffhunk://#diff-f368266b277140cdb2900cd37bbb4546863769b1418381514adc51d65046469cL75-R75)